### PR TITLE
fixed int parsing

### DIFF
--- a/AO3/search.py
+++ b/AO3/search.py
@@ -113,7 +113,7 @@ class Search:
 
         self.results = works
         maindiv = soup.find("div", {"class": "works-search region", "id": "main"})
-        self.total_results = int(maindiv.find("h3", {"class": "heading"}).getText().replace(',','').replace('.','').strip().split(" ")[0])
+        self.total_results = int(maindiv.find("h3", {"class": "heading"}).getText().replace(',','').replace('.','').strip().split(" ")[0].replace(",", ""))
         self.pages = ceil(self.total_results / 20)
 
 def search(


### PR DESCRIPTION
Fixed int parsing in search function for total_results. A stray comma in searches with more than 999 works meant Python treated the string as an invalid literal.